### PR TITLE
Fix for Issue-81: Added worksheet and cell range parameters to xlsread call.

### DIFF
--- a/code/get_bead_peaks.m
+++ b/code/get_bead_peaks.m
@@ -51,7 +51,8 @@ function returned = getBeadCatalog(forceReload)
     persistent catalog;
     if nargin<1, forceReload=false; end;
     if isempty(catalog) || forceReload,
-        [nums txts combo] = xlsread([fileparts(mfilename('fullpath')) '/BeadCatalog.xlsx']);
+        % ISSUE-81: The cell range of the spreadsheet must be updated whenever BeadCatalog.xlsx is updated.
+        [nums txts combo] = xlsread([fileparts(mfilename('fullpath')) '/BeadCatalog.xlsx'], 1, 'A1:M95');
         catalog = parseCatalog(combo);
     end
     returned = catalog;


### PR DESCRIPTION
Discovered cvsread is only for doubles.  So added 2 parameters to the xlsread call.