### PR TITLE
Fixed issue 214

### DIFF
--- a/code/plot_batch_histograms.m
+++ b/code/plot_batch_histograms.m
@@ -6,10 +6,19 @@
 % exception, as described in the file LICENSE in the TASBE analytics
 % package distribution's top directory.
 
-function plot_batch_histograms(results,sampleresults,linespecs,CM)
+function plot_batch_histograms(results,sampleresults,CM,linespecs)
 % Elements of linespecs can either be LineSpecs, or ColorSpecs (e.g. three-element
 % 0..1 vectors representing RGB color values); currently, only single-letter 
 % color linespecs are properly handled.
+
+if (~exist('linespecs', 'var'))
+    % Build linespecs from CM
+    channels = getChannels(CM);
+    linespecs = {1, numel(channels)};
+    for i=1:numel(channels)
+        linespecs{i} = getLineSpec(channels{i});
+    end
+end
 
 n_conditions = size(sampleresults,1);
 n_colors = numel(linespecs);

--- a/tests/test_batchAnalysisOutput.m
+++ b/tests/test_batchAnalysisOutput.m
@@ -54,7 +54,12 @@ n_conditions = size(file_pairs,1);
 TASBEConfig.set('OutputSettings.StemName','LacI-CAGop');
 TASBEConfig.set('plots.plotPath','/tmp/plots');
 TASBEConfig.set('OutputSettings.FixedInputAxis',[1e4 1e10]);
-plot_batch_histograms(results,sampleresults,{'b','y','r'},CM);
+plot_batch_histograms(results,sampleresults,CM,{'b','y','r'});
+
+% Make output plots without linespecs
+TASBEConfig.set('plots.plotPath','/tmp/plots2');
+TASBEConfig.set('OutputSettings.FixedInputAxis',[1e4 1e10]);
+plot_batch_histograms(results,sampleresults,CM);
 
 save('/tmp/LacI-CAGop-batch.mat','AP','bins','file_pairs','results','sampleresults');
 

--- a/tests/test_batch_analysis.m
+++ b/tests/test_batch_analysis.m
@@ -54,7 +54,7 @@ n_conditions = size(file_pairs,1);
 TASBEConfig.set('OutputSettings.StemName','LacI-CAGop');
 TASBEConfig.set('plots.plotPath','/tmp/plots');
 TASBEConfig.set('OutputSettings.FixedInputAxis',[1e4 1e10]);
-plot_batch_histograms(results,sampleresults,{'b','g','r'},CM);
+plot_batch_histograms(results,sampleresults,CM,{'b','g','r'});
 
 save('/tmp/LacI-CAGop-batch.mat','AP','bins','file_pairs','results','sampleresults');
 


### PR DESCRIPTION
Made linespecs for ```plot_batch_histograms.m``` an optional arguement. If it is not passed in, then the linespecs will be generated based on the CM. Also, had to flip the order of CM and linespecs in test files to prevent errors.