### PR TITLE
Correct bug that caused TASBE to ignore peak ID forcing on size beads

### DIFF
--- a/code/@ColorModel/beads_to_um_model.m
+++ b/code/@ColorModel/beads_to_um_model.m
@@ -143,10 +143,11 @@ end
 % Use log scale for fitting to avoid distortions from highest point
 if(n_peaks>=1)
     i = numQuantifiedPeaks-n_peaks; % always assume using top peaks
+    first_peak = i+1;
+    % if forcing, do it before fitting the polynomial
+    if ~isempty(force_peak), first_peak = force_peak-peakOffset; i = first_peak-1; end
     [um_poly,S] = polyfit(log10(peak_means),log10(quantifiedPeakums((1:n_peaks)+i)),1);
     fit_error = S.normr;
-    first_peak = i+1;
-    if ~isempty(force_peak), first_peak = force_peak-peakOffset; end
     
     fprintf('Bead peaks identified as %i to %i of %i\n',first_peak+peakOffset,first_peak+n_peaks-1+peakOffset,numQuantifiedPeaks+peakOffset);
     % Final fit_error should be close to zero / 1-fold

--- a/tests/test_sizebeads.m
+++ b/tests/test_sizebeads.m
@@ -264,3 +264,34 @@ end
 
 assertElementsAlmostEqual(expectedBinCounts,results{1}.bincounts,'relative',1e-2);
 
+
+function test_size_peak_forcing
+
+CM = setupSizePeakCM();
+TASBEConfig.set('sizebeads.forceFirstPeak',1);
+TASBEConfig.set('sizebeads.rangeMax', 5);
+% Execute and save the model
+CM=resolve(CM);
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Check results in CM:
+CMS = struct(CM);
+assertTrue(strcmp(CMS.sizeUnits,'Eum'));
+expected_peaks = 1e5*[0.1257    0.2574    0.6506];
+UT = struct(CMS.size_unit_translation);
+assertElementsAlmostEqual(UT.um_poly,       [0.5565 -1.9418],  'relative', 1e-2);
+assertElementsAlmostEqual(UT.first_peak,    1);
+assertElementsAlmostEqual(UT.fit_error,     0.0099,   'absolute', 0.01);
+assertElementsAlmostEqual(UT.peak_sets{1},  expected_peaks, 'relative', 1e-2);
+
+channels = getChannels(CM);
+% make sure units are right
+assertEqual(getUnits(channels{1}),'MEFL');
+assertEqual(getUnits(channels{2}),'MEFL');
+assertEqual(getUnits(channels{3}),'Eum');
+assertEqual(getUnits(channels{4}),'a.u.');
+% make sure translations are right
+assertElementsAlmostEqual(au_to_ERF(CM,getChannel(CM,1),1),2267.3, 'relative', 1e-2);
+assertElementsAlmostEqual(au_to_ERF(CM,getChannel(CM,2),1),1163.3, 'relative', 1e-2);
+assertElementsAlmostEqual(au_to_ERF(CM,getChannel(CM,3),1),0.0114, 'relative', 1e-2);
+assertElementsAlmostEqual(au_to_ERF(CM,getChannel(CM,4),1),1, 'relative', 1e-2);


### PR DESCRIPTION
Fixes #389 