### PR TITLE
Fix Travis-CI failures caused by trusty-to-xenial migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@
 # available (as of April 2015)
 
 language: java
+dist: trusty
 
 cache:
   - apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@
 # available (as of April 2015)
 
 language: java
-dist: trusty
 
+services:
+  - xvfb
 cache:
   - apt
 env:


### PR DESCRIPTION
When travis deprecated their "trusty" build and shifted projects to "xenial", it broke TASBE's builds because there was no graphic buffer available be default.  This patch follows the travis recommendation for how to migrate.