### PR TITLE
correct "SPILL" to "SPILLOVER" in fca_readfcs.m

### DIFF
--- a/code/fca_readfcs.m
+++ b/code/fca_readfcs.m
@@ -192,7 +192,7 @@ elseif  strcmp(fcsheader_type,'FCS2.0') || strcmp(fcsheader_type,'FCS3.0') || st
     fcshdr.Creator = get_mnemonic_value('CREATOR',fcsheader_main, mnemonic_separator);
     
     % comp matrix reader
-    comp = get_mnemonic_value('SPILL',fcsheader_main,mnemonic_separator); 
+    comp = get_mnemonic_value('SPILLOVER',fcsheader_main,mnemonic_separator); 
     if ~isempty(comp)
         compcell=regexp(comp,',','split');
         nc=str2double(compcell{1});        

--- a/code/fcs_channel_names.m
+++ b/code/fcs_channel_names.m
@@ -11,6 +11,6 @@ function [names, hdr] = fcs_channel_names(filename)
 % exception, as described in the file LICENSE in the TASBE analytics
 % package distribution's top directory.
 
-[~, hdr] = fca_read(filename);
+[~, hdr] = fca_read(DataFile(filename));
 names = {hdr.par(:).name};
 

--- a/code/fcs_channel_names.m
+++ b/code/fcs_channel_names.m
@@ -1,5 +1,5 @@
-function [names, hdr] = fcs_channel_names(filename)
-% [names, hdr] = fcs_channel_names(filename): 
+function [names, hdr] = fcs_channel_names(datafile)
+% [names, hdr] = fcs_channel_names(datafile): 
 %   Returns a cell-array of channel names in an FCS file
 %   The second return is the set of headers that these names have been extracted from 
 
@@ -11,6 +11,8 @@ function [names, hdr] = fcs_channel_names(filename)
 % exception, as described in the file LICENSE in the TASBE analytics
 % package distribution's top directory.
 
-[~, hdr] = fca_read(DataFile(filename));
+if ischar(datafile), datafile = DataFile(filename); end;
+
+[~, hdr] = fca_read(datafile);
 names = {hdr.par(:).name};
 


### PR DESCRIPTION
Found a bug in fca_readfcs; will propagate the fix upstream as well