### PR TITLE
fix FCS read handling of very small files

### DIFF
--- a/code/@AutoFluorescenceModel/AutoFluorescenceModel.m
+++ b/code/@AutoFluorescenceModel/AutoFluorescenceModel.m
@@ -31,8 +31,13 @@ function AFM = AutoFluorescenceModel(channel,data)
         dropsize = ceil(numel(sorted)*dropFraction);
         trimmed = sorted(dropsize:(numel(sorted)-dropsize));
         % compute statistics
-        AFM.af_mean = mean(trimmed);
-        AFM.af_std = std(trimmed);
+        if numel(trimmed)
+            AFM.af_mean = mean(trimmed);
+            AFM.af_std = std(trimmed);
+        else
+            AFM.af_mean = NaN;
+            AFM.af_std = NaN;
+        end
         AFM.n = numel(trimmed);
     else
         TASBESession.error('AutoFluorescence','MissingArgument','Autofluorescence Model constructor requires two arguments');

--- a/code/fca_readfcs.m
+++ b/code/fca_readfcs.m
@@ -179,11 +179,6 @@ elseif  strcmp(fcsheader_type,'FCS2.0') || strcmp(fcsheader_type,'FCS3.0') || st
         return;
     end
     fcshdr.TotalEvents = str2num(get_mnemonic_value('$TOT',fcsheader_main, mnemonic_separator));
-    if fcshdr.TotalEvents == 0
-        fcsdat = 0;
-        fcsdatscaled = 0;
-        return
-    end
     fcshdr.NumOfPar = str2num(get_mnemonic_value('$PAR',fcsheader_main, mnemonic_separator));
 %     if strcmp(mnemonic_separator,'LF')
 %         fcshdr.NumOfPar = fcshdr.NumOfPar + 1;
@@ -495,6 +490,14 @@ if nargout>3 && ~isempty(fcshdr.CompLabels)
     fcsdatcomp = fcsdatscaled;
     fcsdatcomp(:,compcols) = fcsdatcomp(:,compcols)/fcshdr.CompMat;
 else fcsdatcomp=[];
+end
+
+% Finally, if there are no events, add one of all zeros to simplify handling
+if fcshdr.TotalEvents == 0
+    TASBESession.warn('FCS:Read','EmptyFCS',[FileName ' has no events; adding one event of all zeros']);
+    fcsdat = zeros(1,fcshdr.NumOfPar);
+    fcsdatscaled = zeros(1,fcshdr.NumOfPar);
+    % return % JSB changed: report the full header, even if there are no events, for purpose of batch processing.
 end
 
 

--- a/tests/test_small_fcs_files.m
+++ b/tests/test_small_fcs_files.m
@@ -1,0 +1,54 @@
+function test_suite = test_small_fcs_files
+    TASBEConfig.checkpoint('test');
+    try % assignment of 'localfunctions' is necessary in Matlab >= 2016
+        test_functions=localfunctions();
+    catch % no problem; early Matlab versions can use initTestSuite fine
+    end
+    initTestSuite;
+
+function test_small_fcs
+
+% two micro-files, one with 0 events, one with 2 events
+fcs0events = '../TASBEFlowAnalytics-Tutorial/tests/additional_test_files/aq1endun9epg7tm.fcs';
+fcs1events = '../TASBEFlowAnalytics-Tutorial/tests/additional_test_files/aq1endun9efp22g.fcs';
+fcs2events = '../TASBEFlowAnalytics-Tutorial/tests/additional_test_files/aq1enduncr9sukn.fcs';
+fcs79events = '../TASBEFlowAnalytics-Tutorial/tests/additional_test_files/aq1endunfwb9kmg.fcs';
+
+blankfile = fcs0events;
+
+% Create one channel / colorfile pair for each color
+channels = {}; colorfiles = {};
+channels{1} = Channel('BL1-A', 488, 515, 20);
+channels{1} = setPrintName(channels{1}, 'GFP'); % Name to print on charts
+channels{1} = setLineSpec(channels{1}, 'g'); % Color for lines, when needed
+colorfiles{1} = fcs79events;
+
+CM = ColorModel([], blankfile, channels, colorfiles, {});
+
+CM=set_ERF_channel_name(CM, 'BL1-A');
+TASBEConfig.set('flow.channel_template_file',blankfile);
+TASBEConfig.set('calibration.overrideUnits',1);
+
+% Execute and save the model
+CM=resolve(CM);
+
+
+% Configure the analysis
+bins = BinSequence(0,0.1,10,'log_bins');
+AP = AnalysisParameters(bins,{});
+
+% Make a map of condition names to file sets
+file_pairs = {...
+    'small1', {fcs0events, fcs1events, fcs79events, fcs2events};
+    'small2', {fcs79events, fcs2events};
+  };
+
+[results, sampleresults] = per_color_constitutive_analysis(CM,file_pairs,{'GFP'},AP);
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Check results:
+
+assertEqual(numel(results), 2);
+assertElementsAlmostEqual(results{1}.n_events, [1 1 79 2],1e-2);
+assertElementsAlmostEqual(results{2}.n_events, [79 2],1e-2);
+


### PR DESCRIPTION
Patch the FCS reader to make sure that files with zero events get a full header and one event of all zeros.
This should avoid most errors currently caused by zero event FCS files.