### PR TITLE
Range Filter Scatter Plot

### DIFF
--- a/code/@RangeFilter/RangeFilter.m
+++ b/code/@RangeFilter/RangeFilter.m
@@ -45,6 +45,12 @@ RF = class(RF,'RangeFilter',Filter());
 makePlots = TASBEConfig.get('gating.plot');
 
 if makePlots
+    % Check that a blankfile was passed in, if not throw warning and exit
+    if exist('file', 'var') == 0
+       TASBESession.warn('TASBE:RangeFilter','BadRangeFilterFile','No argument was specified as Blankfile, cannot make plot.');
+       return
+    end
+
     % Pull settings from configuration
     visiblePlots = TASBEConfig.get('gating.visiblePlots');
     plotPath = TASBEConfig.get('gating.plotPath');

--- a/code/@RangeFilter/RangeFilter.m
+++ b/code/@RangeFilter/RangeFilter.m
@@ -72,6 +72,7 @@ end
 
 %% Make Plots
 makePlots = TASBEConfig.get('gating.plot');
+visiblePlots = TASBEConfig.get('gating.visiblePlots');
 plotPath = TASBEConfig.get('gating.plotPath');
 plotSize = TASBEConfig.get('gating.plotSize');
 largeOutliers = TASBEConfig.get('gating.largeOutliers');
@@ -87,6 +88,7 @@ if makePlots
 
         % Show background
         h = figure('PaperPosition',[1 1 plotSize]);
+        if(~visiblePlots), set(h,'visible','off'); end;
         smoothhist2D([channel_data(:,i) channel_data(:,i+1)],5,[500, 500],[],type,range,largeOutliers);
         xlabel([clean_for_latex(channel_names{i}) ' a.u.']); 
         ylabel([clean_for_latex(channel_names{i+1}) ' a.u.']);

--- a/code/@RangeFilter/RangeFilter.m
+++ b/code/@RangeFilter/RangeFilter.m
@@ -1,7 +1,8 @@
 % Constructor of RangeFilter class
 % Optional discarding of data outside of a certain range
-% Specified as a sequence of blankfile,'ChannelA',[minA maxA],'ChannelB',[minB maxB]
-%   blankfile: a datafile or string for the data to be used for gating
+% Specified as a sequence of 'ChannelA',[minA maxA],'ChannelB',[minB maxB]
+% Optional argument 'Blankfile': A datafile for the  blank file be used for
+% gating, allows for plotting of selected region of gated channels
 % Also, argument 'Mode' can be 'And' (a value is excluded if any channel is outside), or 'Or' (a value is excluded if all are outside
 % The default mode is 'And'
 %

--- a/code/@RangeFilter/RangeFilter.m
+++ b/code/@RangeFilter/RangeFilter.m
@@ -18,19 +18,18 @@ RF.mode = 'And';
 RF.channels = {};
 RF.ranges = [];
 
-% Set the first argument as the blankfilefile
-file = varargin{1};
-file = ensureDataFile(file);
-[~, fcshdr, rawfcs] = fca_read(file);
-
 % Get the filter information from the remaining arguments
-for i=2:2:numel(varargin)
+for i=1:2:numel(varargin)
     arg = varargin{i};
     value = varargin{i+1};
     if ~ischar(arg), TASBESession.error('TASBE:RangeFilter','BadRangeFilterArgument','Range filter argument %i was not a string',i); end;
     
-    % Either 'Mode' or a channel name
-    if strcmp(arg,'Mode')
+    % Either a datafile, 'Mode' or a channel name
+    if strcmp(arg,'Blankfile')
+        file = value;
+        file = ensureDataFile(file);
+        [~, fcshdr, rawfcs] = fca_read(file);
+    elseif strcmp(arg,'Mode')
         if ~(strcmp(value,'And') || strcmp(value,'Or')), TASBESession.error('TASBE:RangeFilter','BadRangeFilterMode','Unrecognized range filter mode: %s',value); end;
         RF.mode = value;
     else

--- a/code/@RangeFilter/RangeFilter.m
+++ b/code/@RangeFilter/RangeFilter.m
@@ -96,9 +96,7 @@ if makePlots
         hold on;
         
         % Get the bottom left corner and the lengths
-        % These magic numbers assume that your filter is in the same
-        % format as: {'FSC-A', [0 9999], 'SSC-A', [0 9999]}
-        filter_pos = [RF.ranges(i, 1) RF.ranges(i+1, 1) RF.ranges(i, 2)-RF.ranges(i, 1) RF.ranges(i+1, 2)-RF.ranges(i+1, 1)];
+        filter_pos = [log10(RF.ranges(i, 1)) log10(RF.ranges(i+1, 1)) log10(RF.ranges(i, 2)/RF.ranges(i, 1)) log10(RF.ranges(i+1, 2)/RF.ranges(i+1, 1))];
         % Plot a rectangle
         rectangle('Position',filter_pos,'EdgeColor','r','LineWidth',2)
 

--- a/code/@RangeFilter/RangeFilter.m
+++ b/code/@RangeFilter/RangeFilter.m
@@ -1,6 +1,7 @@
 % Constructor of RangeFilter class
 % Optional discarding of data outside of a certain range
 % Specified as a sequence of blankfile,'ChannelA',[minA maxA],'ChannelB',[minB maxB]
+%   blankfile: a datafile or string for the data to be used for gating
 % Also, argument 'Mode' can be 'And' (a value is excluded if any channel is outside), or 'Or' (a value is excluded if all are outside
 % The default mode is 'And'
 %

--- a/code/@RangeFilter/RangeFilter.m
+++ b/code/@RangeFilter/RangeFilter.m
@@ -1,6 +1,6 @@
 % Constructor of RangeFilter class
 % Optional discarding of data outside of a certain range
-% Specified as a sequence of file,'ChannelA',[minA maxA],'ChannelB',[minB maxB]
+% Specified as a sequence of blankfile,'ChannelA',[minA maxA],'ChannelB',[minB maxB]
 % Also, argument 'Mode' can be 'And' (a value is excluded if any channel is outside), or 'Or' (a value is excluded if all are outside
 % The default mode is 'And'
 %
@@ -17,8 +17,10 @@ RF.mode = 'And';
 RF.channels = {};
 RF.ranges = [];
 
-% Set the first argument as the data file
+% Set the first argument as the blankfilefile
 file = varargin{1};
+file = ensureDataFile(file);
+[~, fcshdr, rawfcs] = fca_read(file);
 
 % Get the filter information from the remaining arguments
 for i=2:2:numel(varargin)
@@ -38,10 +40,6 @@ for i=2:2:numel(varargin)
 end
 
 RF = class(RF,'RangeFilter',Filter());
-
-%% Open file
-file = ensureDataFile(file);
-[~, fcshdr, rawfcs] = fca_read(file);
 
 %% Obtain and pre-filter data
 gate_fraction = TASBEConfig.get('gating.fraction');


### PR DESCRIPTION
This code generates a gating scatter plot comparable to the Automatic Gate plots, with a red rectangle highlighting the region selected by the range filter.

This required the blankfile to be passed to the Range Filter constructor as well as the filter information.

The plot is saved in the specified plot folder with the file name RangeFilter-{channel name}-vs-{channal name}.

This does not return the handle of the scatter plot for further customization- that will be submitted in the next pull request.

Example use:
```
blankfile = DataFile('fcs', 'L-1A.fcs');
filter = {'FSC-A', [3.5 4.5], 'SSC-A', [0.75 2.5]};
RF = RangeFilter(blankfile, filter{1}, 10.^filter{2}, filter{3}, 10.^filter{4});
```
Will generate the following plot:
![RangeFilter-FSC-A-vs-SSC-A](https://user-images.githubusercontent.com/40765908/181595047-b1823efb-abf8-47dd-bf5a-4c10e9f42b69.png)

