### PR TITLE
Fix bug in Range Filter Plotting

### DIFF
--- a/code/@RangeFilter/RangeFilter.m
+++ b/code/@RangeFilter/RangeFilter.m
@@ -52,13 +52,7 @@ if makePlots
        return
     end
 
-    % Pull settings from configuration
-    visiblePlots = TASBEConfig.get('gating.visiblePlots');
-    plotPath = TASBEConfig.get('gating.plotPath');
-    plotSize = TASBEConfig.get('gating.plotSize');
-    largeOutliers = TASBEConfig.get('gating.largeOutliers');
-    range = TASBEConfig.getexact('gating.range',[]);
-    density = TASBEConfig.get('gating.density');
+    % Pull settings needed for collecting the channel data
     gate_fraction = TASBEConfig.get('gating.fraction');
     channel_names = TASBEConfig.get('gating.channelNames');
     
@@ -86,6 +80,16 @@ if makePlots
         channel_data(:,i) = unfiltered_channel_data{i}(which);
     end
 
+    % Pull settings needed for making plots
+    visiblePlots = TASBEConfig.get('gating.visiblePlots');
+    plotPath = TASBEConfig.get('gating.plotPath');
+    plotSize = TASBEConfig.get('gating.plotSize');
+    channel_names = TASBEConfig.get('gating.channelNames');
+    largeOutliers = TASBEConfig.get('gating.largeOutliers');
+    range = TASBEConfig.getexact('gating.range',[]);
+    density = TASBEConfig.get('gating.density');
+
+    % Make Plots
     if density >= 1, type = 'image'; else type = 'contour'; end
     
     for i=1:2:n_channels

--- a/tests/test_rangefilter.m
+++ b/tests/test_rangefilter.m
@@ -97,3 +97,7 @@ assert(min(rawdat(:,1))<1e4);
 assert(min(filtdat(:,1))>=1e5);
 assert(min(rawdat(:,3))<1e4);
 assert(min(filtdat(:,3))<1e4);
+
+% Pass the blankfile to RangeFilter to make the gating plot
+RF = RangeFilter('Blankfile', blankfile, 'FSC-A',[2 9], 'SSC-A', [2 9]);
+% TODO: Assert that figure was made?

--- a/tests/test_rangefilter.m
+++ b/tests/test_rangefilter.m
@@ -99,5 +99,9 @@ assert(min(rawdat(:,3))<1e4);
 assert(min(filtdat(:,3))<1e4);
 
 % Pass the blankfile to RangeFilter to make the gating plot
-RF = RangeFilter('Blankfile', blankfile, 'FSC-A',[2 9], 'SSC-A', [2 9]);
+RF = RangeFilter('Blankfile', blankfile, 'Pacific Blue-A',[10 99],'PE-Tx-Red-YG-A',[1 12]);
+Dnew = applyFilter(RF,hdr,data);
 % TODO: Assert that figure was made?
+assert(all(Dnew(:,1) == (5:7)'));
+assert(all(Dnew(:,2) == (8:2:12)'));
+assert(all(Dnew(:,3) == (12:3:18)'));


### PR DESCRIPTION
I introduced a bug during the last pull request (by moving the "Get channel data" section below the part where I get all the settings from TASBE config I overwrote the value for "range" needed for the smoothhist2D plotting).

I have fixed the bug (by moving the part where I get the settings) and have added a test that passes a "Blankfile" argument so that the new code will actually be tested.

The test does not actually check that a plot has been made; it only checks the values of the filtering. 