### PR TITLE
Return plot handle

### DIFF
--- a/code/@GMMGating/GMMGating.m
+++ b/code/@GMMGating/GMMGating.m
@@ -10,7 +10,7 @@
 % exception, as described in the file LICENSE in the TASBE analytics
 % package distribution's top directory.
 
-function GMMG = GMMGating(file)
+function varargout = GMMGating(file)
 
 GMMG.selected_components = [];
 GMMG.channel_names = {};
@@ -137,6 +137,9 @@ GMMG.channel_names = channel_names;
 GMMG.distribution = gmdistribution(dss.mu,dss.Sigma,reweight);
 GMMG.deviations = gate_deviations;
 
+% Always return GMMG
+varargout{1} = GMMG;
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Make the plots
 %%%%
@@ -202,5 +205,8 @@ if makePlots
         plot(gated_sub(which,1),gated_sub(which,2),'r-','LineWidth',2);
 
         outputfig(h,clean_for_latex(sprintf('AutomaticGate-%s-vs-%s',channel_names{i},channel_names{i+1})), plotPath);
+
+        % Return plot handle
+        varargout{2} = h;
     end
 end

--- a/code/@GMMGating/GMMGating.m
+++ b/code/@GMMGating/GMMGating.m
@@ -1,4 +1,4 @@
-% function GMMG = GMMGating(file)
+% function [GMMG, h] = GMMGating(file)
 %   Constructor of GMMGating class, which is a subclass of Filter
 %   file: a datafile or string for the data to be used for gating
 %

--- a/code/@RangeFilter/RangeFilter.m
+++ b/code/@RangeFilter/RangeFilter.m
@@ -14,7 +14,7 @@
 % exception, as described in the file LICENSE in the TASBE analytics
 % package distribution's top directory.
 
-function RF = RangeFilter(varargin)
+function varargout = RangeFilter(varargin)
 RF.mode = 'And';
 RF.channels = {};
 RF.ranges = [];
@@ -41,6 +41,7 @@ for i=1:2:numel(varargin)
 end
 
 RF = class(RF,'RangeFilter',Filter());
+varargout{1} = RF; % Always return RF
 
 %% Obtain data and make plots
 makePlots = TASBEConfig.get('gating.plot');
@@ -112,5 +113,8 @@ if makePlots
 
         % Save
         outputfig(h,clean_for_latex(sprintf('RangeFilter-%s-vs-%s',channel_names{i},channel_names{i+1})), plotPath);
+
+        % Also return the plot handle
+        varargout{2} = h;
     end
 end

--- a/tests/test_autogating.m
+++ b/tests/test_autogating.m
@@ -103,3 +103,6 @@ expected_sigma(:,:,2) = [...
     ];
 assertElementsAlmostEqual(GDS.Sigma,expected_sigma,'absolute',0.01);
 
+% Return the plot handle and check it is the expected type
+[gate, plot_handle] = GMMGating(blankfile);
+assert(isgraphics(plot_handle) == 1);

--- a/tests/test_autogating.m
+++ b/tests/test_autogating.m
@@ -105,4 +105,8 @@ assertElementsAlmostEqual(GDS.Sigma,expected_sigma,'absolute',0.01);
 
 % Return the plot handle and check it is the expected type
 [gate, plot_handle] = GMMGating(blankfile);
+% Debugging
+disp("%%%%%%%%%%%%%%%%%%%%%%%%%%%%% HEY HELEN!!! %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
+disp(class(plot_handle))
+disp("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
 assertTrue(isa(plot_handle, 'matlab.ui.Figure'));

--- a/tests/test_autogating.m
+++ b/tests/test_autogating.m
@@ -105,8 +105,4 @@ assertElementsAlmostEqual(GDS.Sigma,expected_sigma,'absolute',0.01);
 
 % Return the plot handle and check it is the expected type
 [gate, plot_handle] = GMMGating(blankfile);
-% Debugging
-disp("%%%%%%%%%%%%%%%%%%%%%%%%%%%%% HEY HELEN!!! %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
-disp(class(plot_handle))
-disp("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
-assertTrue(isa(plot_handle, 'matlab.ui.Figure'));
+assertTrue(isa(plot_handle, 'double'));

--- a/tests/test_autogating.m
+++ b/tests/test_autogating.m
@@ -104,5 +104,7 @@ expected_sigma(:,:,2) = [...
 assertElementsAlmostEqual(GDS.Sigma,expected_sigma,'absolute',0.01);
 
 % Return the plot handle and check it is the expected type
+% This type check passes on Octave but fails on MATLAB
+% For MATLAB the type is matlab.ui.Figure
 [gate, plot_handle] = GMMGating(blankfile);
 assertTrue(isa(plot_handle, 'double'));

--- a/tests/test_autogating.m
+++ b/tests/test_autogating.m
@@ -105,4 +105,4 @@ assertElementsAlmostEqual(GDS.Sigma,expected_sigma,'absolute',0.01);
 
 % Return the plot handle and check it is the expected type
 [gate, plot_handle] = GMMGating(blankfile);
-assert(isa(plot_handle, 'matlab.ui.Figure'));
+assertTrue(isa(plot_handle, 'matlab.ui.Figure'));

--- a/tests/test_autogating.m
+++ b/tests/test_autogating.m
@@ -105,4 +105,4 @@ assertElementsAlmostEqual(GDS.Sigma,expected_sigma,'absolute',0.01);
 
 % Return the plot handle and check it is the expected type
 [gate, plot_handle] = GMMGating(blankfile);
-assert(isgraphics(plot_handle) == 1);
+assert(isa(plot_handle, 'matlab.ui.Figure'));

--- a/tests/test_rangefilter.m
+++ b/tests/test_rangefilter.m
@@ -105,3 +105,7 @@ Dnew = applyFilter(RF,hdr,data);
 assert(all(Dnew(:,1) == (5:7)'));
 assert(all(Dnew(:,2) == (8:2:12)'));
 assert(all(Dnew(:,3) == (12:3:18)'));
+
+% Return the plot handle and make sure that it is the expected type
+[RF, plot_handle] = RangeFilter('Blankfile', blankfile, 'Pacific Blue-A',[10 99],'PE-Tx-Red-YG-A',[1 12]);
+assert(isgraphics(plot_handle) == 1);

--- a/tests/test_rangefilter.m
+++ b/tests/test_rangefilter.m
@@ -108,4 +108,4 @@ assert(all(Dnew(:,3) == (12:3:18)'));
 
 % Return the plot handle and make sure that it is the expected type
 [RF, plot_handle] = RangeFilter('Blankfile', blankfile, 'Pacific Blue-A',[10 99],'PE-Tx-Red-YG-A',[1 12]);
-assertTrue(isa(plot_handle, 'matlab.ui.Figure'));
+assertTrue(isa(plot_handle, 'double'));

--- a/tests/test_rangefilter.m
+++ b/tests/test_rangefilter.m
@@ -108,4 +108,4 @@ assert(all(Dnew(:,3) == (12:3:18)'));
 
 % Return the plot handle and make sure that it is the expected type
 [RF, plot_handle] = RangeFilter('Blankfile', blankfile, 'Pacific Blue-A',[10 99],'PE-Tx-Red-YG-A',[1 12]);
-assert(isgraphics(plot_handle) == 1);
+assert(isa(plot_handle, 'matlab.ui.Figure'));

--- a/tests/test_rangefilter.m
+++ b/tests/test_rangefilter.m
@@ -108,4 +108,4 @@ assert(all(Dnew(:,3) == (12:3:18)'));
 
 % Return the plot handle and make sure that it is the expected type
 [RF, plot_handle] = RangeFilter('Blankfile', blankfile, 'Pacific Blue-A',[10 99],'PE-Tx-Red-YG-A',[1 12]);
-assert(isa(plot_handle, 'matlab.ui.Figure'));
+assertTrue(isa(plot_handle, 'matlab.ui.Figure'));

--- a/tests/test_rangefilter.m
+++ b/tests/test_rangefilter.m
@@ -107,5 +107,7 @@ assert(all(Dnew(:,2) == (8:2:12)'));
 assert(all(Dnew(:,3) == (12:3:18)'));
 
 % Return the plot handle and make sure that it is the expected type
+% This type check passes on Octave but fails on MATLAB
+% For MATLAB the type is matlab.ui.Figure
 [RF, plot_handle] = RangeFilter('Blankfile', blankfile, 'Pacific Blue-A',[10 99],'PE-Tx-Red-YG-A',[1 12]);
 assertTrue(isa(plot_handle, 'double'));


### PR DESCRIPTION
Use varargout to optionally return the plot handle for scatterplots made in RangeFilter and GMMGating so users can continue to edit the plot.

Added tests to get the plot handle and check the type.