### PR TITLE
Size reference lines

### DIFF
--- a/code/@ColorModel/get_size_unit_translation.m
+++ b/code/@ColorModel/get_size_unit_translation.m
@@ -1,0 +1,12 @@
+% get_size_unit_translation is a getter function for the ColorModel class.
+% 
+% Copyright (C) 2010-2018, Raytheon BBN Technologies and contributors listed 
+% in the AUTHORS file in TASBE analytics package distribution's top directory.
+%
+% This file is part of the TASBE analytics package, and is distributed
+% under the terms of the GNU General Public License, with a linking
+% exception, as described in the file LICENSE in the TASBE analytics
+% package distribution's top directory.
+
+function y=get_size_unit_translation(CM)
+  y = CM.size_unit_translation; % conversion of um channel au to um

--- a/code/@SizeUnitTranslation/um_channel_um_to_AU.m
+++ b/code/@SizeUnitTranslation/um_channel_um_to_AU.m
@@ -1,0 +1,12 @@
+% ERF_CHANNEL_AU_TO_ERF converts ERF channel arbitrary units into standard ERF units
+%
+% Copyright (C) 2010-2018, Raytheon BBN Technologies and contributors listed
+% in the AUTHORS file in TASBE analytics package distribution's top directory.
+%
+% This file is part of the TASBE analytics package, and is distributed
+% under the terms of the GNU General Public License, with a linking
+% exception, as described in the file LICENSE in the TASBE analytics
+% package distribution's top directory.
+    
+function AU = um_channel_um_to_AU(UT, data)
+  AU = (log10(data) - UT.um_poly(2)) / UT.um_poly(1);


### PR DESCRIPTION
Added functions to get the size unit translation from a colormodel and use the size unit translation to go from um to AU.

I.e. After resolving a colormodel you can run the following lines to get the AU values for certain reference sizes and plot them on an open figure (i.e. the one optionally returned by RangeFilter or GMMGating).
```{matlab}
% Get the size unit translation then get the um_poly
size_ut = get_size_unit_translation(CM);

% Pull out vlues for 10, 20, 50 microns
ref_um = [10 20 50];
ref_au = um_channel_um_to_AU(size_ut, ref_um);

% Add to the plots
xline(ref_au, '--r', {'10 microns', '20 microns', '50 microns'}, 'LineWidth', 3)
```

Which produces this figure:
<img width="360" alt="untitled" src="https://user-images.githubusercontent.com/40765908/182230119-09907dd8-7a24-4684-900a-e4de4697a949.png">

